### PR TITLE
Email Template resolution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,11 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.thymeleaf</groupId>
+			<artifactId>thymeleaf-spring5</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 			<scope>runtime</scope>

--- a/src/main/java/com/jjcsa/model/EmailTemplate.java
+++ b/src/main/java/com/jjcsa/model/EmailTemplate.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
+import java.util.UUID;
 
 @Entity
 @Table(name = "email_templates")
@@ -18,7 +19,7 @@ public class EmailTemplate {
     @Id
     @Column(name="template_id", columnDefinition = "uuid")
     @GeneratedValue(strategy = GenerationType.AUTO)
-    private int templateId;
+    private UUID templateId;
 
     @Column(name="template_name", columnDefinition = "varchar(255) default ''", unique=true)
     @NotNull

--- a/src/main/java/com/jjcsa/model/EmailTemplate.java
+++ b/src/main/java/com/jjcsa/model/EmailTemplate.java
@@ -1,0 +1,39 @@
+package com.jjcsa.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+
+@Entity
+@Table(name = "email_templates")
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+public class EmailTemplate {
+    @Id
+    @Column(name="template_id", columnDefinition = "uuid")
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private int templateId;
+
+    @Column(name="template_name", columnDefinition = "varchar(255) default ''", unique=true)
+    @NotNull
+    private String templateName;
+
+    @Column(name="email_subject", columnDefinition = "varchar(255) default ''")
+    @NotNull
+    private String emailSubject;
+
+    @Column(name="email_body", columnDefinition = "text default ''")
+    @NotNull
+    private String emailBody;
+
+    @Column(name="template_status", columnDefinition = "varchar(1) default 'A'")
+    @NotNull
+    private String templateStatus;
+
+}

--- a/src/main/java/com/jjcsa/model/EmailTemplate.java
+++ b/src/main/java/com/jjcsa/model/EmailTemplate.java
@@ -31,9 +31,4 @@ public class EmailTemplate {
     @Column(name="email_body", columnDefinition = "text default ''")
     @NotNull
     private String emailBody;
-
-    @Column(name="template_status", columnDefinition = "varchar(1) default 'A'")
-    @NotNull
-    private String templateStatus;
-
 }

--- a/src/main/java/com/jjcsa/repository/EmailTemplateRepository.java
+++ b/src/main/java/com/jjcsa/repository/EmailTemplateRepository.java
@@ -1,0 +1,12 @@
+package com.jjcsa.repository;
+
+import com.jjcsa.model.EmailTemplate;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface EmailTemplateRepository extends CrudRepository<EmailTemplate, UUID> {
+    EmailTemplate findByTemplateName(String templateName);
+}

--- a/src/main/java/com/jjcsa/service/EmailTemplateService.java
+++ b/src/main/java/com/jjcsa/service/EmailTemplateService.java
@@ -1,0 +1,51 @@
+package com.jjcsa.service;
+
+import com.jjcsa.model.EmailTemplate;
+import com.jjcsa.model.User;
+import com.jjcsa.repository.EmailTemplateRepository;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring5.SpringTemplateEngine;
+import org.thymeleaf.templatemode.TemplateMode;
+import org.thymeleaf.templateresolver.StringTemplateResolver;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@Slf4j
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmailTemplateService {
+
+    @Autowired
+    private SpringTemplateEngine templateEngine;
+    @Autowired
+    private EmailTemplateRepository emailTemplateRepository;
+
+    public String resolveTemplate(Context context, String template){
+        return templateEngine.process(template, context);
+    }
+
+    public String resolveTemplate(User user, String templateName){
+        if(emailTemplateRepository == null) return "Template repository null";
+        EmailTemplate template = emailTemplateRepository.findByTemplateName(templateName);
+        String templateBody = template.getEmailBody();
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("firstName", user.getFirstName());
+        params.put("lastName", user.getLastName());
+        params.put("random", "Random");
+
+        Context context = new Context();
+        context.setVariables(params);
+
+        return resolveTemplate(context, templateBody);
+    }
+}

--- a/src/main/java/com/jjcsa/util/EmailTemplateConfig.java
+++ b/src/main/java/com/jjcsa/util/EmailTemplateConfig.java
@@ -1,0 +1,26 @@
+package com.jjcsa.util;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.thymeleaf.spring5.SpringTemplateEngine;
+import org.thymeleaf.templatemode.TemplateMode;
+import org.thymeleaf.templateresolver.StringTemplateResolver;
+
+@Configuration
+public class EmailTemplateConfig {
+
+    @Bean
+    public SpringTemplateEngine springTemplateEngine() {
+        SpringTemplateEngine templateEngine = new SpringTemplateEngine();
+        templateEngine.addTemplateResolver(htmlStringTemplateResolver());
+        return templateEngine;
+    }
+
+    @Bean
+    public StringTemplateResolver htmlStringTemplateResolver(){
+        StringTemplateResolver emailTemplateResolver = new StringTemplateResolver();
+        emailTemplateResolver.setTemplateMode(TemplateMode.HTML);
+        return emailTemplateResolver;
+    }
+
+}

--- a/src/test/java/com/jjcsa/service/EmailTemplateServiceTest.java
+++ b/src/test/java/com/jjcsa/service/EmailTemplateServiceTest.java
@@ -1,0 +1,13 @@
+package com.jjcsa.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@Slf4j
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class EmailTemplateServiceTest {
+}


### PR DESCRIPTION
## Description

This PR contains changes for email service and template resolution. Test cases haven't been written yet. Just the working functional PR

## Issue

Fixes #<48>

## Checklist
- [ ] Added email template model for database
- [ ] Implemented Thymleaf based HTML resolution
- [ ] Implemented service class for resolution of email template based on the email template name passed and details passed. Currently, it only supports User data for resolution, but changes can be made to handle various types of data objects
- [ ] Implemented config bean for Thymleaf to store config settings.
