### PR TITLE
Sync user id with keycloak user id

### DIFF
--- a/src/main/java/com/jjcsa/controller/LoginController.java
+++ b/src/main/java/com/jjcsa/controller/LoginController.java
@@ -86,29 +86,7 @@ public class LoginController {
 
         AddNewUser addNewUser = objectMapper.readValue(newUserJSONString, AddNewUser.class);
 
-        // Save the new user in our db
-        final User user = userMapper.toUserProfile(addNewUser);
-
-        log.info("Saving user for '{}' ...", addNewUser.getEmail());
-        userService.saveUser(user, jainProofDoc, profPicture);
-        log.info("UserProfile [{}] stored successfully", user);
-        log.info(user.toString());
-
-        // Create the new user in keycloak
-        boolean userCreatedInKeycloak = false;
-        try {
-            userCreatedInKeycloak = keycloakService.createNewUser(addNewUser);
-        } catch (BadRequestException e) {
-            userCreatedInKeycloak = false;
-            throw e;
-        } finally {
-            if(!userCreatedInKeycloak) {
-                log.error("Creating User in Keycloak failed! Deleting from our db");
-                // TODO: Throw exception
-                // Delete the record from our db
-                userService.deleteUserInDbOnly(user);
-            }
-        }
+        userService.saveUser(addNewUser, jainProofDoc, profPicture);
 
         return new ResponseEntity<>(addNewUser, HttpStatus.CREATED);
     }

--- a/src/main/java/com/jjcsa/controller/admin/AdminUserController.java
+++ b/src/main/java/com/jjcsa/controller/admin/AdminUserController.java
@@ -35,10 +35,13 @@ public class AdminUserController {
      * @returns the message on successful deletion of user
      */
     @DeleteMapping(path = "/{userId}")
-    public String deleteUser(@PathVariable UUID userId){
+    public String deleteUser(@PathVariable String userId){
 
         log.info("Delete User invoked for userId:{}", userId);
         User user = userService.getUserById(userId);
+        if(isNull(user)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "User not found");
+        }
         userService.deleteUser(user);
         return "User successfully deleted";
     }
@@ -50,7 +53,7 @@ public class AdminUserController {
     }
 
     @PutMapping(path = "/status")
-    public boolean updateUserStatus(@RequestParam UUID userId, @RequestParam UserStatus status, KeycloakAuthenticationToken authenticationToken) {
+    public boolean updateUserStatus(@RequestParam String userId, @RequestParam UserStatus status, KeycloakAuthenticationToken authenticationToken) {
 
         log.info("Find User for userId: {}", userId);
         User user = userService.getUserById(userId);
@@ -62,7 +65,7 @@ public class AdminUserController {
         SimpleKeycloakAccount account = (SimpleKeycloakAccount) authenticationToken.getDetails();
         AccessToken token = account.getKeycloakSecurityContext().getToken();
 
-        User adminUser = userService.getUser(token.getEmail());
+        User adminUser = userService.getUserById(token.getSubject());
         AdminAction adminAction = new AdminAction();
         adminAction.setFromUserId(adminUser.getId());
         adminAction.setToUserId(userId);

--- a/src/main/java/com/jjcsa/controller/user/UserProfileController.java
+++ b/src/main/java/com/jjcsa/controller/user/UserProfileController.java
@@ -39,7 +39,7 @@ public class UserProfileController {
     public UserProfile getUserProfile(KeycloakAuthenticationToken authenticationToken) {
         SimpleKeycloakAccount account = (SimpleKeycloakAccount) authenticationToken.getDetails();
         AccessToken token = account.getKeycloakSecurityContext().getToken();
-        return userProfileService.getUserProfile(token.getEmail());
+        return userProfileService.getUserProfile(token.getSubject());
     }
 
     @PutMapping()
@@ -51,19 +51,18 @@ public class UserProfileController {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Cannot update email address");
         }
 
-        UserProfile updatedUserProfile = userProfileService.updateUserProfile(token.getEmail(), userProfile);
+        UserProfile updatedUserProfile = userProfileService.updateUserProfile(token.getSubject(), userProfile);
 
         return updatedUserProfile;
     }
 
-    @PutMapping("/{userId}/profPicture")
-    public UserProfile updateUserProfilePicture(@PathVariable("userId") UUID userId,
-                                                @RequestParam("profPicture") MultipartFile profPicture,
+    @PutMapping("/profPicture")
+    public UserProfile updateUserProfilePicture(@RequestParam("profPicture") MultipartFile profPicture,
                                                 KeycloakAuthenticationToken authenticationToken) {
         SimpleKeycloakAccount account = (SimpleKeycloakAccount) authenticationToken.getDetails();
         AccessToken token = account.getKeycloakSecurityContext().getToken();
 
-        User user = userService.getUserById(userId);
+        User user = userService.getUserById(token.getSubject());
         if(isNull(user)) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Cannot find user");
         }

--- a/src/main/java/com/jjcsa/dto/UserProfile.java
+++ b/src/main/java/com/jjcsa/dto/UserProfile.java
@@ -21,7 +21,7 @@ import java.util.UUID;
 @AllArgsConstructor
 @NoArgsConstructor
 public class UserProfile {
-    private UUID id;
+    private String id;
     @NotNull
     private String email;
     private String firstName;

--- a/src/main/java/com/jjcsa/model/AdminAction.java
+++ b/src/main/java/com/jjcsa/model/AdminAction.java
@@ -19,11 +19,11 @@ public @Data class AdminAction{
     @GeneratedValue(strategy = GenerationType.AUTO)
     private UUID actionId;
 
-    @Column(name="from_user_id", columnDefinition = "uuid")
-    private UUID fromUserId;
+    @Column(name="from_user_id")
+    private String fromUserId;
 
-    @Column(name="to_user_id", columnDefinition = "uuid")
-    private UUID toUserId;
+    @Column(name="to_user_id")
+    private String toUserId;
 
 	@JsonFormat(pattern = "dd/MM/yyyy")
     @Column(columnDefinition = "TIMESTAMPTZ")

--- a/src/main/java/com/jjcsa/model/User.java
+++ b/src/main/java/com/jjcsa/model/User.java
@@ -24,8 +24,7 @@ import javax.validation.constraints.Pattern;
 @Builder
 public class User {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
-    private UUID id;
+    private String id;
 
     private String email;
 

--- a/src/main/java/com/jjcsa/repository/UserRepository.java
+++ b/src/main/java/com/jjcsa/repository/UserRepository.java
@@ -9,9 +9,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 @Repository
-public interface UserRepository extends JpaRepository<User, UUID> {
-
-    User findUserById(UUID id);
+public interface UserRepository extends JpaRepository<User, String> {
 
     User findUserByEmail(String email);
 }

--- a/src/test/java/com/jjcsa/mapper/UserProfileMapperTest.java
+++ b/src/test/java/com/jjcsa/mapper/UserProfileMapperTest.java
@@ -55,7 +55,7 @@ public class UserProfileMapperTest {
 
     @Test
     public void shouldMapUserToUserProfile() {
-        UUID uuid = UUID.randomUUID();
+        String uuid = UUID.randomUUID().toString();
         Date date = new Date();
 
         User user = new User().builder()
@@ -125,7 +125,7 @@ public class UserProfileMapperTest {
 
     @Test
     public void shouldMapUserProfileToUser() {
-        UUID uuid = UUID.randomUUID();
+        String uuid = UUID.randomUUID().toString();
         Date date = new Date();
 
         UserProfile userProfile = new UserProfile().builder()

--- a/src/test/java/com/jjcsa/service/UserProfileServiceTest.java
+++ b/src/test/java/com/jjcsa/service/UserProfileServiceTest.java
@@ -39,6 +39,7 @@ public class UserProfileServiceTest {
 
     private User generateUserData() {
         return new User().builder()
+                .id("1")
                 .email("test@test.com")
                 .userStatus(UserStatus.Active)
                 .build();
@@ -63,6 +64,7 @@ public class UserProfileServiceTest {
 
     private UserProfile generateUserProfile() {
         return new UserProfile().builder()
+                .id("1")
                 .email("test@test.com")
                 .education(generateEducationData())
                 .workExperience(generateWorkExData())
@@ -72,14 +74,15 @@ public class UserProfileServiceTest {
 
     @Test
     public void testGetUserProfileFromEmail() {
-        when(userService.getUser(any())).thenReturn(generateUserData());
+        when(userService.getUserById(any())).thenReturn(generateUserData());
         when(educationRepository.findAllByUser(any())).thenReturn(generateEducationData());
         when(workExRepository.findAllByUser(any())).thenReturn(generateWorkExData());
         when(keycloakService.getUserRole(any())).thenReturn(UserRole.USER);
         when(userProfileMapper.toUserProfile(any(), any())).thenReturn(generateUserProfile());
 
-        UserProfile response = userProfileService.getUserProfile("test@test.com");
+        UserProfile response = userProfileService.getUserProfile("1");
         assertNotNull(response);
+        assertEquals(response.getId(), "1");
         assertEquals(response.getEmail(), "test@test.com");
         assertEquals(response.getUserRole(), UserRole.USER);
         assertEquals(response.getEducation().size(), 1);
@@ -90,7 +93,7 @@ public class UserProfileServiceTest {
 
     @Test
     public void testGetUserProfileFromInvalidEmail() {
-        when(userService.getUser(any())).thenReturn(null);
+        when(userService.getUserById(any())).thenReturn(null);
 
         BadRequestException exception = assertThrows(BadRequestException.class, () -> userProfileService.getUserProfile("xyz"));
         assertEquals(exception.getMessage(), "User Profile does not exist");
@@ -101,10 +104,10 @@ public class UserProfileServiceTest {
         User inactiveUser = generateUserData();
         inactiveUser.setUserStatus(UserStatus.Pending);
 
-        when(userService.getUser(any())).thenReturn(inactiveUser);
+        when(userService.getUserById(any())).thenReturn(inactiveUser);
 
         ResponseStatusException exception =
-                assertThrows(ResponseStatusException.class, () -> userProfileService.getUserProfile("test@test.com"));
+                assertThrows(ResponseStatusException.class, () -> userProfileService.getUserProfile("1"));
         assertEquals(exception.getStatus(), HttpStatus.FORBIDDEN);
         assertEquals(exception.getReason(), "User is pending");
     }

--- a/src/test/java/com/jjcsa/service/UserProfileServiceTest.java
+++ b/src/test/java/com/jjcsa/service/UserProfileServiceTest.java
@@ -75,8 +75,8 @@ public class UserProfileServiceTest {
     @Test
     public void testGetUserProfileFromEmail() {
         when(userService.getUserById(any())).thenReturn(generateUserData());
-        when(educationRepository.findAllByUser(any())).thenReturn(generateEducationData());
-        when(workExRepository.findAllByUser(any())).thenReturn(generateWorkExData());
+//        when(educationRepository.findAllByUser(any())).thenReturn(generateEducationData());
+//        when(workExRepository.findAllByUser(any())).thenReturn(generateWorkExData());
         when(keycloakService.getUserRole(any())).thenReturn(UserRole.USER);
         when(userProfileMapper.toUserProfile(any(), any())).thenReturn(generateUserProfile());
 


### PR DESCRIPTION
Fixes #78 

- Updated registration API to first create user in keycloak and use the id created there to save the user to db.
- Refactored Keycloak service to search through id instead of email