### PR TITLE
Add region for s3 bucket in stage

### DIFF
--- a/src/main/resources/application-stage.yml
+++ b/src/main/resources/application-stage.yml
@@ -28,3 +28,8 @@ aws:
     enabled: true
   s3:
     bucketname: stage-jjcsa-usa
+
+cloud:
+  aws:
+    s3:
+      region: us-east-2


### PR DESCRIPTION
The S3 region for stage is us-east-2. But for the old account it was us-east-1.
Updated this...